### PR TITLE
Use node.js fetch and support options in loadURL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "memoryjs": "github:zwfthcks/memoryjs",
-        "node-fetch": "^2.7.0",
         "platform-paths": "^1.2.2",
         "semver": "^7.5.4"
       },
@@ -18,7 +17,7 @@
         "ansi-escapes": "4.3.2"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=18",
         "npm": ">=8.3.0"
       }
     },
@@ -74,25 +73,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/platform-paths": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/platform-paths/-/platform-paths-1.2.2.tgz",
@@ -110,25 +90,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/yallist": {
@@ -175,14 +136,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "platform-paths": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/platform-paths/-/platform-paths-1.2.2.tgz",
@@ -194,25 +147,6 @@
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
-      }
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,10 @@
   "homepage": "https://github.com/zwfthcks/zwift-memory-monitor#readme",
   "engines": {
     "npm": ">=8.3.0",
-    "node": ">=14.18.0"
+    "node": ">=18"
   },
   "dependencies": {
     "memoryjs": "github:zwfthcks/memoryjs",
-    "node-fetch": "^2.7.0",
     "platform-paths": "^1.2.2",
     "semver": "^7.5.4"
   },

--- a/src/examples/example-fetch.js
+++ b/src/examples/example-fetch.js
@@ -43,5 +43,5 @@ zmm.on('status.loaded', () => {
 })
 
 zmm.once('ready', () => {
-    zmm.loadURL('https://cdn.jsdelivr.net/gh/zwfthcks/zwift-memory-monitor@main/build/data/lookup-playerstate.json')
+    zmm.loadURL('https://cdn.jsdelivr.net/gh/zwfthcks/zwift-memory-monitor@main/build/data/lookup-playerstate.json', { cache: 'no-cache' })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,6 @@ const memoryjs = require('memoryjs');
 const semver = require('semver')
 const { getDocumentsPath } = require('platform-paths');
 
-// const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
-const fetch = require('node-fetch').default
-
 const fs = require('node:fs');
 const path = require('node:path')
 const os = require('node:os')
@@ -145,9 +142,10 @@ class ZwiftMemoryMonitor extends EventEmitter {
    * 
    *
    * @param {*} fetchLookupURL
+   * @param {*} options 
    * @memberof ZwiftMemoryMonitor
    */
-  loadURL(fetchLookupURL) {
+  loadURL(fetchLookupURL, options = {}) {
 
     if (!this._ready) return false;
 
@@ -157,7 +155,7 @@ class ZwiftMemoryMonitor extends EventEmitter {
       this.emit('status.loaded')
       
     } else {
-      fetch(fetchLookupURL)
+      fetch(fetchLookupURL, options)
       .then((response) => {
         return response.json();
       })


### PR DESCRIPTION
Removed dependency on node-fetch, using the built-in node.js fetch() instead.
Added options object as parameter to loadURL, e.g. to control caching. Possible options as per fetch() documentation.