### PR TITLE
Bump version to 2.6.2 and improve logging for Zwift version file retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zwfthcks/zwift-memory-monitor",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "monitor Zwift memory and emit events for player state updates",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -727,9 +727,9 @@ class ZwiftMemoryMonitor extends EventEmitter {
       try {
         let zwiftVerCurFilename = fs.readFileSync(this._options.zwiftVerCurFilenameTxt, 'utf8').trim()
         let zwiftVerCurFile = path.resolve(this._options.zwiftAppFolder, zwiftVerCurFilename)
-        this.log('Zwift version file:', zwiftVerCurFile)
         // remove trailing null bytes from zwiftVerCurFile
         zwiftVerCurFile = zwiftVerCurFile.replace(/\0/g, '')
+        this.log('Zwift version file:', zwiftVerCurFile)
         let xml = fs.readFileSync(zwiftVerCurFile, 'utf8') 
         // <Zwift version="1.0.139872" sversion="1.83.0 (139872)" gbranch="rc/1.83.0" gcommit="298e0a13bf6c23cfedb09968ae9490965c9e369c" GAME_URL="https://us-or-rly101.zwift.com" manifest="Zwift_1.0.139872_34608a9e_manifest.xml" manifest_checksum="-1006471014" ver_cur_checksum="-1183981758"/>
         // Find the version number in the XML in the sversion attribute


### PR DESCRIPTION
Update the package version to 2.6.2 and enhance logging by stripping zero bytes from the Zwift version file before logging its path.